### PR TITLE
Add event time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ $RECYCLE.BIN/
 # Roslyn VS2015 junk
 *.sln.ide/
 *.nupkg
+
+# Visual Studio temp and user data 
+*/.vs/

--- a/Source/CSharpAnalytics.Tests/Properties/AssemblyInfo.cs
+++ b/Source/CSharpAnalytics.Tests/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Resources;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]
 [assembly: AssemblyDescriptionAttribute("Unit tests for CSharpAnalytics")]
 [assembly: NeutralResourcesLanguageAttribute("")]

--- a/Source/CSharpAnalytics.Tests/Protocols/Measurement/MeasurementAnalyticsClientTests.cs
+++ b/Source/CSharpAnalytics.Tests/Protocols/Measurement/MeasurementAnalyticsClientTests.cs
@@ -115,14 +115,14 @@ namespace CSharpAnalytics.Test.Protocols.Measurement
         }
 
         [TestMethod]
-        public void MeasurementAnalyticsClient_AdjustUriBeforeRequest_Adds_Qt_Parameter()
+        public void MeasurementAnalyticsClient_AdjustUriBeforeRequest_Adds_TimeStamp_Parameters()
         {
             var originalUri = new Uri("http://anything.really.com/something#" + DateTime.UtcNow.ToString("o"));
 
             var actual = new MeasurementAnalyticsClient().AdjustUriBeforeRequest(originalUri);
 
             StringAssert.Contains(actual.Query, "qt=");
-        }
+            StringAssert.Contains(actual.Query, "et=");        }
 
         [TestMethod]
         public void MeasurementAnalyticsClient_AdjustUriBeforeRequest_Clears_Fragment()

--- a/Source/CSharpAnalytics.Tests/Protocols/Measurement/MeasurementAnalyticsClientTests.cs
+++ b/Source/CSharpAnalytics.Tests/Protocols/Measurement/MeasurementAnalyticsClientTests.cs
@@ -115,13 +115,14 @@ namespace CSharpAnalytics.Test.Protocols.Measurement
         }
 
         [TestMethod]
-        public void MeasurementAnalyticsClient_AdjustUriBeforeRequest_Adds_Qt_Parameter()
+        public void MeasurementAnalyticsClient_AdjustUriBeforeRequest_Adds_TimeStamp_Parameters()
         {
             var originalUri = new Uri("http://anything.really.com/something#" + DateTime.UtcNow.ToString("o"));
 
             var actual = new MeasurementAnalyticsClient().AdjustUriBeforeRequest(originalUri);
 
             StringAssert.Contains(actual.Query, "qt=");
+            StringAssert.Contains(actual.Query, "et=");
         }
 
         [TestMethod]

--- a/Source/CSharpAnalytics/Properties/AssemblyInfo.cs
+++ b/Source/CSharpAnalytics/Properties/AssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]
 [assembly: ComVisible(false)]
 
 [assembly: InternalsVisibleTo("CSharpAnalytics.Test.Net45")]

--- a/Source/CSharpAnalytics/Protocols/Measurement/MeasurementAnalyticsClient.cs
+++ b/Source/CSharpAnalytics/Protocols/Measurement/MeasurementAnalyticsClient.cs
@@ -269,6 +269,9 @@ namespace CSharpAnalytics.Protocols.Measurement
             DateTime utcHitTime;
             if (!DateTime.TryParse(decodedFragment, out utcHitTime)) return;
 
+            //Event Time "et": add non measurement protocol parameter, can be used by a server side dispatcher to re-adjust "qt" 
+            parameters["et"] = utcHitTime.ToString("O");
+
             var queueTime = DateTimeOffset.Now.Subtract(utcHitTime);
             if (queueTime.TotalMilliseconds < 0) return;
 

--- a/Source/Samples/CSharpAnalytics.Sample.WinForms/Properties/AssemblyInfo.cs
+++ b/Source/Samples/CSharpAnalytics.Sample.WinForms/Properties/AssemblyInfo.cs
@@ -7,6 +7,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("CSharpAnalytics")]
 [assembly: AssemblyCopyright("Copyright © 2012-2014 Attack Pattern LLC.")]
 
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
Added "et" (EventTime) parameter. 
"et" is not a measurement protocol parameter, it can be used at a server side dispatcher (if there is one) to adjust "qt". "et" will be ignored by Google.